### PR TITLE
Fixed numeric sorting of times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.o
 *.log*
 *.version
+*.DS_Store
+*/.idea
 .sass-cache
 wwjarsigner.key
 wwsccapps*.jar


### PR DESCRIPTION
Times in the announcer panel were sorting alphabetically, causing early runs and novices to appear at the top of the list.  I also added some IDE and Mac specific things to the .gitignore file.
